### PR TITLE
Fixes for scatterlist allocation, and interrupt race condition

### DIFF
--- a/dnvme_ds.c
+++ b/dnvme_ds.c
@@ -285,7 +285,7 @@ int driver_log(struct nvme_file *n_file)
                     pmetrics_cq_list->private_cq.prp_persist.data_buf_size);
                 vfs_write(file, work, strlen(work), &pos);
                 snprintf(work, SIZE_OF_WORK, IDNT_L4"sq = 0X%llX",
-                    (u64)pmetrics_cq_list->private_cq.prp_persist.sg);
+                    (u64)pmetrics_cq_list->private_cq.prp_persist.st.sgl);
                 vfs_write(file, work, strlen(work), &pos);
                 snprintf(work, SIZE_OF_WORK, IDNT_L4"num_map_pgs = 0X%llX",
                     (u64)pmetrics_cq_list->private_cq.prp_persist.num_map_pgs);
@@ -375,7 +375,7 @@ int driver_log(struct nvme_file *n_file)
                     pmetrics_sq_list->private_sq.prp_persist.data_buf_size);
                 vfs_write(file, work, strlen(work), &pos);
                 snprintf(work, SIZE_OF_WORK, IDNT_L4"sg = 0X%llX",
-                    (u64)pmetrics_sq_list->private_sq.prp_persist.sg);
+                    (u64)pmetrics_sq_list->private_sq.prp_persist.st.sgl);
                 vfs_write(file, work, strlen(work), &pos);
                 snprintf(work, SIZE_OF_WORK, IDNT_L4"num_map_pgs = 0X%llX",
                     (u64)pmetrics_sq_list->private_sq.prp_persist.num_map_pgs);
@@ -436,7 +436,7 @@ int driver_log(struct nvme_file *n_file)
                          pcmd_track_list->prp_nonpersist.data_buf_size);
                     vfs_write(file, work, strlen(work), &pos);
                     snprintf(work, SIZE_OF_WORK, IDNT_L6"sg = 0X%llX",
-                         (u64)pcmd_track_list->prp_nonpersist.sg);
+                         (u64)pcmd_track_list->prp_nonpersist.st.sgl);
                     vfs_write(file, work, strlen(work), &pos);
                     snprintf(work, SIZE_OF_WORK, IDNT_L6"num_map_pgs = 0X%llX",
                          (u64)pcmd_track_list->prp_nonpersist.num_map_pgs);

--- a/dnvme_ds.h
+++ b/dnvme_ds.h
@@ -48,8 +48,8 @@ struct nvme_prps {
     dma_addr_t first_dma; /* First entry in PRP List */
     /* Size of data buffer for the specific command */
     u32 data_buf_size;
-    /* Pointer to SG list generated */
-    struct scatterlist *sg;
+    /* SG table use sg_next(nvme_prps.st.sgl) */
+    struct sg_table st;
     /* Number of pages mapped to DMA area */
     u32 num_map_pgs;
     /* Address of data buffer for the specific command */
@@ -135,6 +135,7 @@ struct irq_track {
     u32               int_vec;        /* vec number; assigned by OS */
     u8                isr_fired;      /* flag to indicate if irq has fired */
     u32               isr_count;      /* total no. of times irq fired */
+    u32               outstanding_cmd_count; /* count of outstanding cmds */
 };
 
 /*

--- a/dnvme_irq.h
+++ b/dnvme_irq.h
@@ -170,4 +170,13 @@ int reap_inquiry_isr(struct metrics_cq  *pmetrics_cq_node,
 int reset_isr_flag(struct metrics_device_list *pmetrics_device,
     u16 irq_no);
 
+/* update incr outstanding cmd count
+ */
+int incr_outstanding_cmd_count(struct metrics_device_list *pmetrics_device,
+    u16 irq_no);
+
+int sub_outstanding_cmd_count(struct metrics_device_list *pmetrics_device,
+    u16 irq_no, u32 reaped_count);
+
+
 #endif

--- a/dnvme_queue.c
+++ b/dnvme_queue.c
@@ -741,7 +741,7 @@ u32 reap_inquiry(struct metrics_cq  *pmetrics_cq_node, struct device *dev)
             (comp_entry_size * (u32)pmetrics_cq_node->public_cq.head_ptr);
     } else {
         /* do sync and update when pointer to discontig Q is reaped inq */
-        dma_sync_sg_for_cpu(dev, pmetrics_cq_node->private_cq.prp_persist.sg,
+        dma_sync_sg_for_cpu(dev, pmetrics_cq_node->private_cq.prp_persist.st.sgl,
             pmetrics_cq_node->private_cq.prp_persist.num_map_pgs,
             pmetrics_cq_node->private_cq.prp_persist.data_dir);
         queue_base_addr =
@@ -1430,6 +1430,13 @@ int driver_reap_cq(struct  metrics_device_list *pmetrics_device,
     pos_cq_head_ptr(pmetrics_cq_node, user_data->num_reaped);
     writel(pmetrics_cq_node->public_cq.head_ptr, pmetrics_cq_node->
         private_cq.dbs);
+
+    if ((pmetrics_cq_node->public_cq.irq_enabled == 1) && 
+        (pmetrics_device->metrics_device->public_dev.irq_active.irq_type != INT_NONE)) {
+        sub_outstanding_cmd_count(pmetrics_device, 
+            pmetrics_cq_node->public_cq.irq_no, user_data->num_reaped);
+    }
+
 
     /* if 0 CE in a given cq, then reset the isr flag. */
     if ((pmetrics_cq_node->public_cq.irq_enabled == 1) &&


### PR DESCRIPTION
Switch from contiguous raw scatterlist to use scatterlist table api instead (which allocates a page at a time for the scatterlist, then chains them together), fixes memory alloc failure when host memory gets fragmented enough to not be able to allocate enough memory for a contiguous scatterlist.

Don't increment ISR count, and mask interupts, if no outstanding commands. This prevents test failure due to race between reaped completion, unmasking interrupts, and device canceling interrupt, sometimes spurious interrupt may occur that arrive the moment interrupts are unmasked, causing the next interrupt to be masked.
